### PR TITLE
Fix TypeError on t411 plugin

### DIFF
--- a/flexget/plugins/urlrewrite/torrent411.py
+++ b/flexget/plugins/urlrewrite/torrent411.py
@@ -418,7 +418,7 @@ class UrlRewriteTorrent411(object):
                 raise UrlRewritingError("Connection Error for %s : %s" % (url, e))
             rawdata = response.read()
 
-            match = re.search(r"<a href=\"/torrents/download/\?id=(\d*?)\">.*\.torrent</a>", rawdata)
+            match = re.search(r"<a href=\"/torrents/download/\?id=(\d*?)\">.*\.torrent</a>", str(rawdata))
             if match:
                 torrent_id = match.group(1)
                 log.debug("Got the Torrent ID: %s" % torrent_id)


### PR DESCRIPTION
### Motivation for changes:

```
2016-08-11 18:49 ERROR    urlrewriter   t411series task cannot use a string pattern on a bytes-like object
Traceback (most recent call last):
  File "/usr/lib/python3.5/site-packages/flexget/plugins/plugin_urlrewriting.py", line 70, in url_rewrite
    urlrewriter.instance.url_rewrite(task, entry)
  File "/usr/lib/python3.5/site-packages/flexget/plugins/urlrewrite/torrent411.py", line 421, in url_rewrite
    match = re.search(r"<a href=\"/torrents/download/\?id=(\d*?)\">.*\.torrent</a>", rawdata)
  File "/usr/lib/python3.5/re.py", line 173, in search
    return _compile(pattern, flags).search(string)
TypeError: cannot use a string pattern on a bytes-like object
```

### Detailed changes:

- Just a type.

### Addressed issues:

- None

### Config usage if relevant (new plugin or updated schema):
```
tasks:
  test tak 
```
### Log and/or tests output (preferably both):
```
paste output here
```


